### PR TITLE
Add an option for enabling HWE kernel

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,5 @@ target_dir: "{{ ansible_env.HOME }}/.local/ansible_ubuntu-autoinstall"
 ubuntu_gpg_key: 843938DF228D22F7B3742BC0D94AA3F0EFE21092
 
 enable_pikvm: false
+
+enable_hwe_kernel: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,4 @@ target_dir: "{{ ansible_env.HOME }}/.local/ansible_ubuntu-autoinstall"
 
 ubuntu_gpg_key: 843938DF228D22F7B3742BC0D94AA3F0EFE21092
 
-grub_escape_seq: \\\
-
 enable_pikvm: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,5 @@ ubuntu_gpg_key: 843938DF228D22F7B3742BC0D94AA3F0EFE21092
 enable_pikvm: false
 
 enable_hwe_kernel: false
+
+enable_swap_file: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,13 +3,11 @@
   become: yes
   package:
     name:
-      - p7zip-full
       - xorriso
       - gpg
       - curl
     state: present
   with_items:
-    - p7zip-full
     - xorriso
     - gpg
     - curl
@@ -17,8 +15,7 @@
 
 - name: Install dependencies (macOS)
   package:
-    name: 
-      - p7zip
+    name:
       - xorriso
       - gnupg
       - curl

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,10 +7,6 @@
       - gpg
       - curl
     state: present
-  with_items:
-    - xorriso
-    - gpg
-    - curl
   when: ansible_os_family != "Darwin"
 
 - name: Install dependencies (macOS)

--- a/tasks/download_verify.yml
+++ b/tasks/download_verify.yml
@@ -1,4 +1,4 @@
----  
+---
 - name: Download the SHA256 sums
   get_url:
     url: "https://cdimage.ubuntu.com/ubuntu-server/focal/daily-live/current/SHA256SUMS"
@@ -7,6 +7,7 @@
 - name: Get the SHA256 sum for the {{ iso_arch }} ISO
   shell:
     cmd: "grep {{ iso_arch }} {{ target_dir }}/SHA256SUMS | cut -d ' ' -f1"
+  changed_when: "false"
   register: sha256sum
 
 - name: Download the latest Ubuntu Server 20.04 {{ iso_arch }} ISO
@@ -20,6 +21,10 @@
     url: "https://cdimage.ubuntu.com/ubuntu-server/focal/daily-live/current/SHA256SUMS.gpg"
     dest: "{{ target_dir }}"
 
+- name: Install psutil module
+  pip:
+    name: psutil
+
 - name: Check if dirmngr is running
   pids:
     name: dirmngr
@@ -27,13 +32,13 @@
 
 - name: Launch dirmngr if it isn't running
   shell:
-    cmd: "dirmngr"
+    cmd: "dirmngr --daemon"
   when: dirmngr_pids.pids | length == 0
 
 - name: Import the GPG key
   shell:
     cmd: "gpg -q --no-default-keyring --keyring '{{ target_dir }}/{{ ubuntu_gpg_key }}.keyring' --keyserver 'hkp://keyserver.ubuntu.com' --recv-keys {{ ubuntu_gpg_key }}"
-    creates: 
+    creates:
      - "{{ target_dir }}/{{ ubuntu_gpg_key }}.keyring"
      - "{{ target_dir }}/{{ ubuntu_gpg_key }}.keyring~"
   ignore_errors: yes

--- a/tasks/download_verify.yml
+++ b/tasks/download_verify.yml
@@ -7,7 +7,7 @@
 - name: Get the SHA256 sum for the {{ iso_arch }} ISO
   shell:
     cmd: "grep {{ iso_arch }} {{ target_dir }}/SHA256SUMS | cut -d ' ' -f1"
-  changed_when: "false"
+  changed_when: false
   register: sha256sum
 
 - name: Download the latest Ubuntu Server 20.04 {{ iso_arch }} ISO
@@ -21,19 +21,17 @@
     url: "https://cdimage.ubuntu.com/ubuntu-server/focal/daily-live/current/SHA256SUMS.gpg"
     dest: "{{ target_dir }}"
 
-- name: Install psutil module
-  pip:
-    name: psutil
-
 - name: Check if dirmngr is running
-  pids:
-    name: dirmngr
-  register: dirmngr_pids
+  shell:
+    cmd: pgrep dirmngr
+  failed_when: false
+  changed_when: false
+  register: dirmngr_status
 
 - name: Launch dirmngr if it isn't running
   shell:
     cmd: "dirmngr --daemon"
-  when: dirmngr_pids.pids | length == 0
+  when: dirmngr_status.rc != 0
 
 - name: Import the GPG key
   shell:
@@ -51,4 +49,4 @@
 - name: Kill dirmngr if we launched it
   shell:
     cmd: "pkill dirmngr"
-  when: dirmngr_pids.pids | length == 0
+  when: dirmngr_status.rc != 0

--- a/tasks/generate_iso.yml
+++ b/tasks/generate_iso.yml
@@ -1,4 +1,4 @@
----  
+---
 - name: Create the extraction directory
   file:
     path: "{{ target_dir }}/iso"
@@ -6,7 +6,14 @@
 
 - name: Extract the ISO
   shell:
-    cmd: "7z -y x {{ target_dir }}/focal-live-server-{{ iso_arch }}.iso -o{{ target_dir }}/iso"
+    cmd: "xorriso -osirrox on -indev {{ target_dir }}/focal-live-server-{{ iso_arch }}.iso -extract / {{ target_dir }}/iso"
+
+- name: Fix extracted ISO mode
+  file:
+    path: "{{ target_dir }}/iso"
+    mode: "u+w"
+    recurse: yes
+    follow: no
 
 - name: Delete the [BOOT] folder
   file:
@@ -93,11 +100,9 @@
   file:
     path: "{{ item }}"
     state: absent
-  with_items: 
+  with_items:
     - "{{ target_dir }}/iso"
 
 - name: Done!
   debug:
     msg: "Done! The ISO file has been generated: {{target_dir}}/ubuntu_autoinstall_{{ iso_arch }}.iso"
-    
-  

--- a/tasks/generate_iso.yml
+++ b/tasks/generate_iso.yml
@@ -20,6 +20,25 @@
     path: "{{ target_dir }}/iso/[BOOT]"
     state: absent
 
+- name: Enable HWE kernel in ISOLinux bootloader
+  replace:
+    path: "{{ item }}"
+    regexp: '/casper/(vmlinuz|initrd)'
+    replace: '/casper/hwe-\1'
+  with_items:
+    - "{{ target_dir }}/iso/isolinux/txt.cfg"
+  when: iso_arch == 'amd64' and enable_hwe_kernel | default(False)
+
+- name: Enable HWE kernel in GRUB bootloader
+  replace:
+    path: "{{ item }}"
+    regexp: '/casper/(vmlinuz|initrd)'
+    replace: '/casper/hwe-\1'
+  with_items:
+    - "{{ target_dir }}/iso/boot/grub/grub.cfg"
+    - "{{ target_dir }}/iso/boot/grub/loopback.cfg"
+  when: enable_hwe_kernel | default(False)
+
 - name: Add the autoinstall parameter to the ISOLinux bootloader
   replace:
     path: "{{ item }}"

--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -4,7 +4,7 @@ autoinstall:
   locale: {{ locale }}
   keyboard:
     layout: {{ keyboard_layout }}
-  refresh-installer: 
+  refresh-installer:
     update: yes
   identity:
     hostname: {{ hostname }}
@@ -13,13 +13,15 @@ autoinstall:
   ssh:
     install-server: true
     allow-pw: false
-    authorized-keys: 
+    authorized-keys:
       - {{ ssh_public_key }}
   storage:
     grub:
       reorder_uefi: False
+{% if not enable_swap_file %}
     swap:
       size: 0
+{% endif %}
     config:
     - {ptable: gpt, serial: "{{ boot_drive_serial }}", preserve: false, name: '', grub_device: false, type: disk, id: bootdrive}
 


### PR DESCRIPTION
I've also replaced `7z` with `xorriso` as it was done in this commit: https://github.com/covertsh/ubuntu-autoinstall-generator/commit/5c93e34e4cf7bd25e769df19364145f5ec44d1b0
And fixed `tasks/download_verify.yml` _(otherwise it fails on Ubuntu machine)_

And also, I've added an option for leaving swap file configuration as-is _(basically enabling swap file)_.