### PR TITLE
Modified grep for extracting sha256

### DIFF
--- a/tasks/download_verify.yml
+++ b/tasks/download_verify.yml
@@ -6,7 +6,7 @@
 
 - name: Get the SHA256 sum for the {{ iso_arch }} ISO
   shell:
-    cmd: "grep {{ iso_arch }} {{ target_dir }}/SHA256SUMS | cut -d ' ' -f1"
+    cmd: "grep {{ iso_arch }}.iso {{ target_dir }}/SHA256SUMS | cut -d ' ' -f1"
   changed_when: false
   register: sha256sum
 


### PR DESCRIPTION
### Short description

Returned two sha256 values from SHA256SUMS when only grepping for amd64.
In my case it returned the sha256 for *focal-live-server-amd64+intel-iot.iso and for *focal-live-server-amd64.iso. By this the my playbook always failed. :)

### Error message
```
fatal: [localhost]: FAILED! => {"changed": true, "checksum_dest": "d5a341cf52c370c5b963ccdf6af499c965bc0900", "checksum_src": "c0bba0ee31061768f92685d54a987f0e75bf44cb", "dest": "/Users/.../.local/ansible_ubuntu-autoinstall/focal-live-server-amd64.iso", "elapsed": 144, "msg": "The checksum for /Users/.../.local/ansible_ubuntu-autoinstall/focal-live-server-amd64.iso did not match fa8c5008fad67c2f120902720e1081a27566989c574de04a65a59524823dfad95035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4; it was 5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4.", "src": "/Users/.../.ansible/tmp/ansible-tmp-1661947961.408468-95058-275084806107407/tmpyy3vh2an", "url": "https://cdimage.ubuntu.com/ubuntu-server/focal/daily-live/current/focal-live-server-amd64.iso"}
```

### SHA256 Sums
```
fa8c5008fad67c2f120902720e1081a27566989c574de04a65a59524823dfad9 *focal-live-server-amd64+intel-iot.iso
227dd8f8167f6358cab0b0480c2f3bf3555b217af3f4d95bc5c199a51d9da298 *focal-live-server-amd64.iso
e42d6373dd39173094af5c26cbf2497770426f42049f8b9ea3e60ce35bebdedf *focal-live-server-arm64.iso
a407be10267e85dc354a93efa414bd1308c0607a4391d55fd968ce766062385f *focal-live-server-ppc64el.iso
2a1190aaa7d719c4fc0b1aba278a78d3721db692b026a2d3a2c97f0b0e0b0cec *focal-live-server-s390x.iso
227dd8f8167f6358cab0b0480c2f3bf3555b217af3f4d95bc5c199a51d9da298 *focal-live-server-amd64.iso
e42d6373dd39173094af5c26cbf2497770426f42049f8b9ea3e60ce35bebdedf *focal-live-server-arm64.iso
a407be10267e85dc354a93efa414bd1308c0607a4391d55fd968ce766062385f *focal-live-server-ppc64el.iso
2a1190aaa7d719c4fc0b1aba278a78d3721db692b026a2d3a2c97f0b0e0b0cec *focal-live-server-s390x.iso
```